### PR TITLE
Autofocus search input when opening page

### DIFF
--- a/views/app.erb
+++ b/views/app.erb
@@ -5,7 +5,7 @@
     <button type="button" class="_mobile-btn _menu-btn">Menu</button>
     <button type="button" class="_mobile-btn _home-btn">Home</button>
     <form class="_search" role="search">
-      <input type="search" class="_search-input" placeholder="Search&hellip;" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="30" aria-label="Search">
+      <input type="search" class="_search-input" placeholder="Search&hellip;" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="30" aria-label="Search" autofocus="autofocus">
       <button type="reset" class="_search-clear" title="Clear search">Clear search</button>
       <div class="_search-tag"></div>
     </form>


### PR DESCRIPTION
For some reason, on my Firefox/Linux (even when started with `-safe-mode` and/or `-private`), the search field is not focused. This pull request should fix that.
